### PR TITLE
Manually bring back chart 0.22.0

### DIFF
--- a/actions-runner-controller/index.yaml
+++ b/actions-runner-controller/index.yaml
@@ -19,6 +19,23 @@ entries:
     - https://github.com/actions/actions-runner-controller/releases/download/actions-runner-controller-0.23.0/actions-runner-controller-0.23.0.tgz
     version: 0.23.0
   - apiVersion: v2
+    appVersion: 0.27.0
+    created: "2023-01-16T09:38:49.246894956Z"
+    description: A Kubernetes controller that operates self-hosted runners for GitHub
+      Actions on your Kubernetes cluster.
+    digest: 40f9e67d28a6aa5498c77bfc16339ab75df1e7dae42a438bb153f83348dd41ea
+    home: https://github.com/actions/actions-runner-controller
+    maintainers:
+    - name: actions-runner-controller
+      url: https://github.com/actions-runner-controller
+    name: actions-runner-controller
+    sources:
+    - https://github.com/actions/actions-runner-controller
+    type: application
+    urls:
+    - https://github.com/actions/actions-runner-controller/releases/download/actions-runner-controller-0.22.0/actions-runner-controller-0.22.0.tgz
+    version: 0.22.0
+  - apiVersion: v2
     appVersion: 0.26.0
     created: "2022-10-25T19:13:34.478190277Z"
     description: A Kubernetes controller that operates self-hosted runners for GitHub


### PR DESCRIPTION
https://github.com/actions/actions-runner-controller/actions/runs/4559513962/jobs/8043555734 accidentally removed the index entry for the previous chart version v0.22.0, which resulted in some users unable to install the chart without bumping the version number...
This fixes that, by manually bringing back the removed old version.
I'll shortly follow up with fixing the original workflow that triggered this so that we won't repeated this every time we cut a new release.
Thanks for your understanding and support!


---

@Link- I believe we need to fix the chart publishing workflow to prevent this from happening on every new chart release.

Currently, our chart publishing workflow runs the `cr` utility against https://github.com/actions/actions-runner-controller/blob/gh-pages/index.yaml (see [here](https://github.com/actions/actions-runner-controller/blob/42abad5def1a294a52a49dc6b14f6753b212b472/.github/workflows/publish-chart.yaml#L167-L174)) and write the updated index.yaml to https://github.com/actions-runner-controller/actions-runner-controller.github.io/blob/master/actions-runner-controller/index.yaml (see [here](https://github.com/actions/actions-runner-controller/blob/42abad5def1a294a52a49dc6b14f6753b212b472/.github/workflows/publish-chart.yaml#L187-L198)).

And this means we throw away the change made via the previous release every time we cut a new release because we don't write back the updated `index.yaml` to https://github.com/actions/actions-runner-controller/blob/gh-pages/index.yaml...